### PR TITLE
Extract paletteFromHue into module and add tests

### DIFF
--- a/html code
+++ b/html code
@@ -16,8 +16,9 @@
 <body>
 <canvas id="c"></canvas>
 <div class="hint">Binary Rain — mic reacts to sound • F: fullscreen • B: palette</div>
-<script>
-(async function () {
+  <script type="module">
+  import { paletteFromHue } from './palette.js';
+  (async function () {
   const canvas = document.getElementById('c');
   const ctx = canvas.getContext('2d');
 
@@ -54,14 +55,6 @@
     {base:"#a3ff00", shadow:"#2a3b00"},
     {base:"#ffffff", shadow:"#1a1a1a"}
   ];
-
-  function paletteFromHue(h){
-    if (h < 120)  return 0; // bassy -> green
-    if (h < 200)  return 1; // low-mid -> blue
-    if (h < 280)  return 2; // high-mid -> lime
-    return 3;               // highs -> white
-  }
-
   let palIdxSmoothed = 0;
   function autoPalette(hue){
     const target = paletteFromHue(hue);

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "binary_rain",
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "test": "node --test"
+  }
+}

--- a/palette.js
+++ b/palette.js
@@ -1,0 +1,6 @@
+export function paletteFromHue(h) {
+  if (h < 120) return 0;
+  if (h < 200) return 1;
+  if (h < 280) return 2;
+  return 3;
+}

--- a/palette.test.js
+++ b/palette.test.js
@@ -1,0 +1,12 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import { paletteFromHue } from './palette.js';
+
+test('paletteFromHue returns correct index around thresholds', () => {
+  assert.strictEqual(paletteFromHue(119), 0);
+  assert.strictEqual(paletteFromHue(120), 1);
+  assert.strictEqual(paletteFromHue(199), 1);
+  assert.strictEqual(paletteFromHue(200), 2);
+  assert.strictEqual(paletteFromHue(279), 2);
+  assert.strictEqual(paletteFromHue(280), 3);
+});


### PR DESCRIPTION
## Summary
- refactor HTML to import paletteFromHue from new palette.js module
- add standalone paletteFromHue export
- add node-based tests for paletteFromHue around hue thresholds

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f848e5cd08327ba147b9b2f40e8bc