### PR TITLE
Remove palette control hint

### DIFF
--- a/html code
+++ b/html code
@@ -15,7 +15,7 @@
 </head>
 <body>
 <canvas id="c"></canvas>
-<div class="hint">Binary Rain — mic reacts to sound • F: fullscreen • B: palette</div>
+<div class="hint">Binary Rain — mic reacts to sound • F: fullscreen</div>
 <script>
 (async function () {
   const canvas = document.getElementById('c');


### PR DESCRIPTION
## Summary
- remove palette toggle reference from on-screen hint to match current controls

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689f8482a4248327948513e9d371c061