### PR TITLE
Add demo mode and usage docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,23 @@
-# binary_rain
-simple audio visualizer training
-im just messing around with html, may change up a bit to mess with it more
+# Binary Rain
+
+Simple bit-rain visualizer driven by your microphone.
+
+## Run
+
+1. Open `index.html` in a modern browser. For a local server you can run:
+
+   ```bash
+   npx http-server .
+   ```
+
+2. Click the page to enable mic input. A demo animation runs until permission is granted.
+3. Press `F` to toggle fullscreen.
+
+## Tests
+
+```bash
+npm test
+```
+
+Runs a small unit test for the palette helper.
+

--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@
 </head>
 <body>
 <canvas id="c"></canvas>
-<div class="hint">Binary Rain — mic reacts to sound • F: fullscreen</div>
+<div class="hint">Binary Rain — click to enable mic • F: fullscreen</div>
   <script type="module">
   import { paletteFromHue } from './palette.js';
   (async function () {
@@ -121,10 +121,13 @@
     requestAnimationFrame(frame);
     const dt = Math.min(0.04, (t - lastT)/1000); lastT = t;
 
-    // If we have audio, update hue/energy first
+    // If we have audio, update hue/energy first. Otherwise run demo mode
     if (started) {
       const ep = getEnergyAndPitch();
       lastHue = ep.hue;
+    } else {
+      lastHue = (lastHue + dt * 40) % 360; // slow hue cycle
+      beatBoost = 1 + Math.sin(t / 500) * 0.3; // gentle pulse
     }
 
     // Background fade using a valid palette derived from lastHue
@@ -133,8 +136,6 @@
     ctx.globalAlpha = 0.30;
     ctx.fillRect(0,0,innerWidth,innerHeight);
     ctx.globalAlpha = 1;
-
-    if (!started) return; // wait for mic to start before drawing glyphs
 
     // Draw columns
     ctx.fillStyle = `hsl(${lastHue}, 90%, 65%)`;


### PR DESCRIPTION
## Summary
- Animate binary rain even without microphone input via a demo mode
- Hint to click for mic access and keep palette logic in separate module
- Replace README with run and test instructions

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f8b7a77448327ba1b556957f2c755